### PR TITLE
Use HTTPS URLs where possible

### DIFF
--- a/specs/json/index.html
+++ b/specs/json/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset='utf-8'>
     <title>W3C HTML JSON form submission</title>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
               specStatus:   "unofficial"
@@ -14,7 +14,7 @@
           ,   wgURI:        "http://www.w3.org/html/wg/"
           ,   wgPublicList: "public-html"
           ,   wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/40318/status"
-          ,   edDraftURI:   "http://darobin.github.com/formic/specs/json/"
+          ,   edDraftURI:   "https://darobin.github.com/formic/specs/json/"
           ,   license:      "cc-by"
           ,   bugTracker: {
                   open: "https://github.com/darobin/formic/issues?labels=json&page=1&state=open"
@@ -327,13 +327,13 @@
       <ul>
         <li>
           The types
-          <dfn><a href='http://people.mozilla.org/~jorendorff/es5.html#sec-15.12.1.2'><code>JSONObject</code></a></dfn>
+          <dfn><a href='https://people.mozilla.org/~jorendorff/es5.html#sec-15.12.1.2'><code>JSONObject</code></a></dfn>
           and
-          <dfn><a href='http://people.mozilla.org/~jorendorff/es5.html#sec-15.12.1.2'><code>JSONArray</code></a></dfn>.
+          <dfn><a href='https://people.mozilla.org/~jorendorff/es5.html#sec-15.12.1.2'><code>JSONArray</code></a></dfn>.
         </li>
         <li>
           The
-          <dfn><a href='http://people.mozilla.org/~jorendorff/es5.html#sec-15.12.3'>stringify</a></dfn> operation.
+          <dfn><a href='https://people.mozilla.org/~jorendorff/es5.html#sec-15.12.3'>stringify</a></dfn> operation.
         </li>
       </ul>
     </section>


### PR DESCRIPTION
This avoids the mixed content warnings on `https://darobin.github.io/formic/specs/json/`.
